### PR TITLE
Remove InAppBrowser package import

### DIFF
--- a/src/android/ThemeableBrowser.java
+++ b/src/android/ThemeableBrowser.java
@@ -79,7 +79,6 @@ import org.apache.cordova.LOG;
 import org.apache.cordova.PluginManager;
 import org.apache.cordova.PluginResult;
 import org.apache.cordova.Whitelist;
-import org.apache.cordova.inappbrowser.InAppBrowser;
 import org.json.JSONException;
 import org.json.JSONObject;
 


### PR DESCRIPTION
The cordova inappbrowser package no longer seems to be available, and removing it resolves a build issue.